### PR TITLE
Add peak Bx initial condition and run divergence cleaning

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -29,7 +29,8 @@ int main(){
     std::string out_dir = prepare_output_dir();
 
     FlowField flow(nx,ny,dx,dy);
-    initialize_test_field(flow);
+    // Use peak Bx initial condition from the divergence cleaning paper
+    initialize_peak_bx(flow);
 
     auto t0=std::chrono::high_resolution_clock::now();
     for(int step=0; step<=max_steps; ++step){

--- a/physics.cpp
+++ b/physics.cpp
@@ -73,3 +73,30 @@ void initialize_test_field(FlowField& flow) {
         }
     }
 }
+
+// Peak Bx test from "Hyperbolic Divergence Cleaning for the MHD Equations"
+// Uniform fluid with a localized magnetic perturbation creating non-zero
+// divergence initially.
+void initialize_peak_bx(FlowField& flow) {
+    #pragma omp parallel for collapse(2)
+    for (int i = 0; i < flow.bx.nx; ++i) {
+        for (int j = 0; j < flow.bx.ny; ++j) {
+            double x = flow.bx.x0 + i * flow.bx.dx - 0.5;
+            double y = flow.bx.y0 + j * flow.bx.dy - 0.5;
+
+            flow.rho.data[i][j] = 1.0;           // constant density
+            flow.u.data[i][j]   = 0.0;           // initially at rest
+            flow.v.data[i][j]   = 0.0;
+            flow.p.data[i][j]   = 1.0;           // constant pressure
+            flow.e.data[i][j]   = 1.0/(1.4 - 1.0);
+
+            // Magnetic field: By uniform, Bx localized Gaussian peak
+            double r2 = x*x + y*y;
+            double peak = std::exp(-r2 / 0.01);  // narrow Gaussian
+            flow.bx.data[i][j] = peak;           // localized divergence source
+            flow.by.data[i][j] = 0.0;
+
+            flow.psi.data[i][j] = 0.0;
+        }
+    }
+}

--- a/physics.hpp
+++ b/physics.hpp
@@ -4,3 +4,6 @@ void initialize_MHD_disk(FlowField& flow, int seed = 12345);
 void add_divergence_error(FlowField& flow, double amplitude = 0.1);
 // Initialize a simple magnetic field test function for divergence cleaning
 void initialize_test_field(FlowField& flow);
+// Initial condition inspired by "Hyperbolic Divergence Cleaning for the MHD Equations"
+// Peak Bx problem: uniform state with a localized magnetic perturbation
+void initialize_peak_bx(FlowField& flow);


### PR DESCRIPTION
## Summary
- add new initialization `initialize_peak_bx` following the GLM divergence cleaning paper
- use the new initial condition in `main.cpp`

## Testing
- `bash run.sh` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684ab07cce68832eac16fea1f0080738