### PR TITLE
Implement full GLM-MHD evolution

### DIFF
--- a/io.cpp
+++ b/io.cpp
@@ -1,4 +1,5 @@
 #include "io.hpp"
+#include "solver.hpp"
 #include <fstream>
 #include <filesystem>
 
@@ -21,6 +22,11 @@ void save_flow_MHD(const FlowField& flow,const std::string& dir,int step){
     dump_scalar(flow.e,   prefix+"e_"+std::to_string(step)+".csv");
     dump_scalar(flow.bx,  prefix+"bx_"+std::to_string(step)+".csv");
     dump_scalar(flow.by,  prefix+"by_"+std::to_string(step)+".csv");
+    dump_scalar(flow.psi, prefix+"psi_"+std::to_string(step)+".csv");
+
+    auto errs = compute_divergence_errors(flow);
+    std::ofstream div_out(prefix+"divB_"+std::to_string(step)+".csv");
+    div_out << errs.first << ',' << errs.second << '\n';
 }
 
 void save_amr_grid(const AMRGrid& amr,const std::string& dir,int step){


### PR DESCRIPTION
## Summary
- drive the main program using the full MHD solver
- disable magnetic diffusion
- implement second-order Runge–Kutta update
- save psi and divergence errors in output

## Testing
- `g++ -O3 -fopenmp *.cpp -o ns2d`
- `./ns2d`
- `python3 analysis_divergence.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684ab3f71998832ea510411f6974109b