### PR TITLE
Add OpenMP timing

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -35,6 +35,7 @@ int main(){
     initialize_peak_bx(flow);      // peak Bx initial condition
     std::vector<FlowField> flows = {flow};
 
+    reset_omp_compute_time();
     double t0 = omp_get_wtime();
     for(int step=0; step<=max_steps; ++step){
         double dt = compute_cfl_timestep(flows[0]);
@@ -52,11 +53,13 @@ int main(){
     }
     double t1 = omp_get_wtime();
     double elapsed = t1 - t0;
-    std::cout << "Total time " << elapsed << " s\n";
+    double omp_elapsed = get_omp_compute_time();
+    std::cout << "Total time " << elapsed << " s (OpenMP " << omp_elapsed << " s)\n";
 
-    std::ofstream time_file(out_dir +"time.txt");
+    std::ofstream time_file(out_dir + "/time.txt");
     if(time_file.is_open()){
         time_file << elapsed << "\n";
+        time_file << omp_elapsed << "\n";
     }
     return 0;
 }

--- a/solver.hpp
+++ b/solver.hpp
@@ -9,3 +9,6 @@ std::pair<double, double> compute_divergence_errors(const FlowField& flow);
 void damp_divergence(FlowField& flow, double dt);
 // Single explicit GLM divergence cleaning step
 void divergence_cleaning_step(FlowField& flow, double dt);
+extern double omp_compute_time;
+double get_omp_compute_time();
+void reset_omp_compute_time();


### PR DESCRIPTION
## Summary
- instrument all OpenMP regions to accumulate compute time
- expose helper functions for retrieving/resetting the timer
- report OpenMP compute time in `main.cpp`

## Testing
- `g++ -O3 -fopenmp *.cpp -o ns2d`
- `./ns2d`

------
https://chatgpt.com/codex/tasks/task_e_684ad8021b5c832eb4ee33d6d3f3fa20